### PR TITLE
Ruby-SFCC gemspec should build extension

### DIFF
--- a/sfcc.gemspec
+++ b/sfcc.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("mocha", [">= 0.9"])
   s.add_development_dependency("yard", [">= 0.5"])
   s.add_development_dependency("shoulda", [">= 0"])
+  s.extensions	<< 'ext/sfcc/extconf.rb'
 
   s.files        = Dir.glob("lib/**/*.rb") + Dir.glob("ext/**/*.{rb,h,c}") + %w(CHANGELOG.rdoc README.rdoc)
   s.require_path = 'lib'


### PR DESCRIPTION
Without this commit, I get, when trying to use Active CIM:

irb(main):001:0> require 'rubygems'
=> true
irb(main):002:0> require 'active_cim/base'
DEPRECATION WARNING: require "activesupport" is deprecated and will be removed in Rails 3. Use require "active_support" instead.. (called from /usr/lib64/ruby/gems/1.8/gems/activesupport-2.3.5/lib/activesuppor
t.rb:2)
MissingSourceFile: no such file to load -- sfcc.so [long stack trace snipped]

Let me know if you have any concerns.  Thanks.
--Will.
