### PR TITLE
Provide a way to pass type information along with value to methods

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,4 +1,5 @@
 == 0.6.1
+* fixed memory leak in client's invokeMethod
 * added support for Float and Bignum in Cim::Data creation
 * fixed accessing char array in CIMCValue
 * enabled compilation for older sblim-sfcc

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,4 +1,5 @@
 == 0.6.1
+* added support for Float and Bignum in Cim::Data creation
 * fixed accessing char array in CIMCValue
 * enabled compilation for older sblim-sfcc
 

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,7 @@
+== 0.6.1
+* fixed accessing char array in CIMCValue
+* enabled compilation for older sblim-sfcc
+
 == 0.6.0
 
 * Support native Ruby calls to CIM instance methods

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,4 +1,6 @@
 == 0.6.1
+* added support for conversion of Cim::ObjectPath, Cim::Instance,
+  Cim::Enumeration and Cim::Class to CIMCData
 * supported instantiation of Cim::Data
 * fixed memory leak in client's invokeMethod
 * added support for Float and Bignum in Cim::Data creation

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,4 +1,5 @@
 == 0.6.1
+* fixed memory leak in Class
 * added support for conversion of Cim::ObjectPath, Cim::Instance,
   Cim::Enumeration and Cim::Class to CIMCData
 * supported instantiation of Cim::Data

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,4 +1,5 @@
 == 0.6.1
+* supported instantiation of Cim::Data
 * fixed memory leak in client's invokeMethod
 * added support for Float and Bignum in Cim::Data creation
 * fixed accessing char array in CIMCValue

--- a/examples/data_instantiation.rb
+++ b/examples/data_instantiation.rb
@@ -18,6 +18,8 @@ data = Cim::Data.from_value(15)
 puts "Data created from integer(#{data.value}): #{data}"
 data = Cim::Data.from_value([1, 4, 9, 10])
 puts "Data created from array(from #{data.value.inspect}): #{data}"
+data = Cim::Data.from_value(Cim::ObjectPath.new("namespace", "class_name"))
+puts "Data created from object path: #{data}"
 
 # creating data from type and value
 data = Cim::Data.new(Cim::Type::String, "Data(type=string):")

--- a/examples/data_instantiation.rb
+++ b/examples/data_instantiation.rb
@@ -1,0 +1,48 @@
+%w(../ext/sfcc ../lib).each do |path|
+  $LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(__FILE__), path)))
+end
+ 
+require 'rubygems'
+require 'sfcc'
+
+include Sfcc
+
+#
+# instantiate Cim::Data class
+#
+
+# creating data from rb value
+data = Cim::Data.from_value("Data created from string:")
+puts "#{data.value} #{data}"
+data = Cim::Data.from_value(15)
+puts "Data created from integer(#{data.value}): #{data}"
+data = Cim::Data.from_value([1, 4, 9, 10])
+puts "Data created from array(from #{data.value.inspect}): #{data}"
+
+# creating data from type and value
+data = Cim::Data.new(Cim::Type::String, "Data(type=string):")
+puts "#{data.value} #{data}"
+data = Cim::Data.new(Cim::Type::UInt8, 10)
+puts "Data(type=UInt8): #{data}"
+data = Cim::Data.new(Cim::Type::UInt8, -40)
+puts "Data(type=UInt8) from value -40 (overflow): #{data}"
+data = Cim::Data.new(Cim::Type::SInt16, 2**15)
+puts "Data(type=SInt16) from value (2**15) (overflow): #{data}"
+# type can be passed also as string
+data = Cim::Data.new("String", "created with type passed as string")
+puts "Data(type=String): #{data}"
+data = Cim::Data.new("Reference", Cim::ObjectPath.new("namespace", "ClassName"))
+puts "Data(type=Reference): #{data}"
+
+# changing type and value of created data
+data.type = "UInt8"
+data.value = 42
+begin # this will raise a TypeError
+    data.value = ["abcd"]
+rescue TypeError
+    puts("you can not change the value of data with different type" +
+         " before you set the corresponding type")
+end
+data.type = "StringA" # this will destroy kept value
+puts "Data(type=StringA): #{data}"
+data.value = ["abcd", "efgh"] # this will pass

--- a/ext/sfcc/cim_class.c
+++ b/ext/sfcc/cim_class.c
@@ -22,8 +22,11 @@ static VALUE class_name(VALUE self)
   CIMCStatus status = { 0 };
   Data_Get_Struct(self, CIMCClass, cimclass);
   name = cimclass->ft->getClassName(cimclass, &status);
-  if ( !status.rc )
-    return CIMSTR_2_RUBYSTR(name);
+  if ( !status.rc ) {
+    VALUE ret = CIMSTR_2_RUBYSTR(name);
+    name->ft->release(name);
+    return ret;
+  }
 
   sfcc_rb_raise_if_error(status, "Can't retrieve class name");
   return Qnil;

--- a/ext/sfcc/cim_data.c
+++ b/ext/sfcc/cim_data.c
@@ -1,12 +1,385 @@
-
-#include "cim_data.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include "cim_class.h"
+#include "cim_instance.h"
+#include "cim_enumeration.h"
+#include "cim_object_path.h"
+#include "cim_string.h"
 #include "cim_type.h"
+#include "sfcc.h"
+#include "cim_data.h"
 
-static void
-dealloc(CIMCData *data)
+VALUE cSfccCimData;
+
+/**
+ * CIMCData needs to be wrapped in this struct together with information
+ * whether clear_cimdata should be called upon it on destruction
+ */
+typedef struct {
+  CIMCData data;
+  /* Says, whether data contains value, that needs to be freed
+   * upon Cim::Data destruction or not.
+   * When true, the value will not be freed.
+   */
+  bool reference;
+}rb_sfcc_data;
+
+/**
+ * just releases kept value, unsets the value and sets
+ * the state to CIMC_nullValue
+ */
+static void clear_cimdata(CIMCData *d)
 {
-/*  fprintf(stderr, "Sfcc_dealloc_data %p\n", data); */
-  free(data);
+  if (  ((d)->type < CIMC_instance  || (d)->type > CIMC_dateTime)
+     && ((d)->type < CIMC_instanceA || (d)->type > CIMC_dateTimeA)
+     && d->type != CIMC_chars && d->type != CIMC_charsptr
+     && !(d->type & CIMC_ARRAY)) return;
+
+  if (d->state != CIMC_goodValue && d->state != CIMC_keyValue) return;
+
+  if (d->type & CIMC_ARRAY) {
+    d->value.array->ft->release(d->value.array);
+  }else {
+    switch (d->type) {
+      case CIMC_instance: d->value.inst->ft->release(d->value.inst); break;
+      case CIMC_ref: d->value.ref->ft->release(d->value.ref); break;
+      //case CIMC_args: not supported
+      case CIMC_class: d->value.cls->ft->release(d->value.cls); break;
+      //case CIMC_filter: d->value.filter->ft->release(d->value.filter); break;
+      case CIMC_enumeration: d->value.Enum->ft->release(d->value.Enum); break;
+      case CIMC_string: d->value.string->ft->release(d->value.string); break;
+      case CIMC_dateTime: d->value.dateTime->ft->release(d->value.dateTime); break;
+      case CIMC_chars: free(d->value.chars); break;
+      case CIMC_charsptr:
+         free(d->value.dataPtr.ptr);
+         d->value.dataPtr.length = 0;
+         break;
+      default: break;
+    }
+  }
+  d->state = CIMC_nullValue;
+  memset(&d->value, 0, sizeof(CIMCValue));
+}
+
+/**
+ * frees the wrapping structure and possibly referenced value
+ */
+static void
+dealloc(rb_sfcc_data *rd)
+{
+  if (!rd->reference) {
+    clear_cimdata(&rd->data);
+  }
+  free(rd);
+}
+
+/**
+ * sets the Cim::Data's type
+ *
+ * it deallocates CIMCData's value in case the type is different from current
+ * one
+ */
+static void do_set_type(rb_sfcc_data *data, VALUE type)
+{
+  char buf[100];
+  snprintf(buf, 100, "expected Type instance, Symbol,"
+          " String or Fixnum, not: %s",
+          to_charptr(rb_obj_class(type)));
+  VALUE type_except = rb_exc_new2(rb_eTypeError, buf);
+
+  switch (TYPE(type)) {
+    case T_STRING:
+      type = rb_intern(STR2CSTR(type));
+    case T_SYMBOL:
+      type = rb_const_get(cSfccCimType, type); break;
+    case T_DATA:
+      if (CLASS_OF(type) != cSfccCimType) {
+        rb_exc_raise(type_except);
+        return;
+      }
+      type = INT2FIX(Sfcc_rb_type_to_cimtype(type));
+    case T_FIXNUM:
+      if (!Sfcc_cim_type_to_cstr(FIX2UINT(type))) return;
+      break;
+    default:
+      data->data.state = CIMC_badValue;
+      rb_exc_raise(type_except);
+      return;
+  }
+  if (data->data.type != (CIMCType) FIX2UINT(type)) {
+    if (!data->reference) clear_cimdata(&data->data);
+    data->reference = false;
+    data->data.type = (CIMCType) FIX2UINT(type);
+    data->data.state = CIMC_nullValue;
+  }
+}
+
+/**
+ * helper macro used to set value of CIMCData in case of wrapped object
+ * in structure rb_sfcc_...
+ *
+ * @param data_type_suf is a suffix of ruby klass beginning with cSfccCim
+ * @param struct_suf is a suffix for rb_sfcc_ structure for corresponding type
+ * @param struct_attr is attribute name used to access value in this structure
+ * @param value_attr is attribute name used to access value of corresponding type
+ *                   in CIMCValue
+ * @param cimc_suf is a suffix of cimc type beggining with CIMC_
+ */
+#define STORE_DATA_VAL(data_type_suf, struct_suf, struct_attr, value_attr, cimc_suf) \
+  if (CLASS_OF(value) == cSfccCim ## data_type_suf) { \
+    if (d->type == CIMC_ ## cimc_suf) { \
+      rb_sfcc_ ## struct_suf * tmp; \
+      Data_Get_Struct(value, rb_sfcc_ ## struct_suf, tmp); \
+      d->value.value_attr = tmp->struct_attr; \
+      data->reference = true; \
+    }else { \
+      d->state = CIMC_badValue; \
+      rb_raise(rb_eTypeError, #data_type_suf \
+            " object can only be set for " #cimc_suf " type"); \
+    } \
+  } \
+
+/**
+ * sets the value of Cim::Data
+ *
+ * @param value will be transformed to cimc data and then stored
+ */
+static void do_set_value(rb_sfcc_data *data, VALUE value)
+{
+  // dealloc previously kept value
+  if (!data->reference) clear_cimdata(&data->data);
+  CIMCData *d = &data->data;
+  data->reference = false;
+  d->state = CIMC_goodValue;
+
+  switch (TYPE(value)) {
+    case T_NIL:
+      d->state = CIMC_nullValue;
+      break;
+
+    case T_SYMBOL:  // first make a string out of symbol
+      value = rb_any_to_s(value);
+    case T_STRING:
+      if ((d->type & (CIMC_UINT | CIMC_char16))) {
+        // handle unsigned numbers passed as string
+        uint64_t tmp = NUM2ULL(rb_str2inum(value, 10));
+        switch (d->type) {
+          case CIMC_uint32: d->value.uint32 = tmp; break;
+          case CIMC_uint16: d->value.uint16 = tmp; break;
+          case CIMC_uint8:  d->value.uint8 = tmp; break;
+          default: d->value.uint64 = tmp; break;
+        }
+      }else if (d->type & CIMC_SINT) {
+        // handle signed numbers passed as string
+        int64_t tmp = NUM2LL(rb_str2inum(value, 10));
+        switch (d->type) {
+          case CIMC_sint32: d->value.sint32 = tmp; break;
+          case CIMC_sint16: d->value.sint16 = tmp; break;
+          case CIMC_sint8: d->value.sint8 = tmp; break;
+          default: d->value.sint64 = tmp; break;
+        }
+      }else if (d->type & CIMC_REAL) {
+        // handle reals passed as string
+        double tmp = NUM2LL(rb_Float(value));
+        switch (d->type) {
+          case CIMC_real32: d->value.real32 = tmp; break;
+          default: d->value.real64 = tmp; break;
+        }
+      }else if (d->type == CIMC_string) {
+        d->value.string = cimcEnv->ft->newString(
+                cimcEnv, STR2CSTR(value), NULL);
+      }else if (d->type == CIMC_chars) {
+        d->value.chars = strdup(STR2CSTR(value));
+      }else if (d->type == CIMC_charsptr) {
+        d->value.dataPtr.ptr = strdup(STR2CSTR(value));
+        d->value.dataPtr.length = rb_funcall(
+                value, rb_intern("length"), 0);
+      }else {
+        d->state = CIMC_badValue;
+        rb_raise(rb_eTypeError, "unsupported data type(%s) for value"
+                ", when data.type set to \"%s\"",
+                to_charptr(rb_obj_class(value)),
+                Sfcc_cim_type_to_cstr(d->type));
+      }
+      break;
+
+    case T_TRUE:
+    case T_FALSE:
+      if (d->type != CIMC_boolean) {
+        d->state = CIMC_badValue;
+        rb_raise(rb_eTypeError, "boolean values are supported only"
+               " for CIMC_boolean type");
+        d->value.boolean = TYPE(value) == T_TRUE;
+      }
+      break;
+
+    case T_FIXNUM:
+    case T_BIGNUM:
+    case T_FLOAT:
+      if ((d->type & (CIMC_UINT | CIMC_char16))) {
+        // handle unsigned numbers
+        uint64_t tmp = NUM2ULL(value);
+        switch (d->type) {
+          case CIMC_uint32: d->value.uint32 = tmp; break;
+          case CIMC_uint16: d->value.uint16 = tmp; break;
+          case CIMC_uint8:  d->value.uint8 = tmp; break;
+          default: d->value.uint64 = tmp; break;
+        }
+      }else if (d->type & CIMC_SINT) {
+        // handle signed numbers
+        int64_t tmp = NUM2LL(value);
+        switch (d->type) {
+          case CIMC_sint32: d->value.sint32 = tmp; break;
+          case CIMC_sint16: d->value.sint16 = tmp; break;
+          case CIMC_sint8: d->value.sint8 = tmp; break;
+          default: d->value.sint64 = tmp; break;
+        }
+      }else if (d->type & CIMC_REAL) {
+        // handle real numbers
+        double tmp = NUM2DBL(value);
+        switch (d->type) {
+          case CIMC_real32: d->value.real32 = tmp; break;
+          default: d->value.real64 = tmp; break;
+        }
+
+      // try to convert numbers to string
+      }else if (d->type == CIMC_string) {
+        d->value.string = cimcEnv->ft->newString(
+                cimcEnv, STR2CSTR(sfcc_numeric_to_str(value)), NULL);
+      }else if (d->type == CIMC_chars) {
+        d->value.chars = strdup(STR2CSTR(sfcc_numeric_to_str(value)));
+      }else if (d->type == CIMC_charsptr) {
+        VALUE tmp = sfcc_numeric_to_str(value);
+        d->value.dataPtr.ptr = strdup(STR2CSTR(tmp));
+        d->value.dataPtr.length = rb_funcall(
+                tmp, rb_intern("length"), 0);
+      }else {
+        d->state = CIMC_badValue;
+        rb_raise(rb_eTypeError, "unsupported data type(%s) for value"
+                ", when data.type set to \"%s\"",
+                to_charptr(rb_obj_class(value)),
+                Sfcc_cim_type_to_cstr(d->type));
+      }
+      break;
+
+    case T_ARRAY:
+      if (d->type & CIMC_ARRAY) {
+        if (!(d->value.array = sfcc_rubyarray_to_cimcarray(
+                        value, &d->type)))
+            d->state = CIMC_badValue;
+      }else {
+        rb_raise(rb_eTypeError, "unsupported data type(%s) for value"
+                ", when data.type set to \"%s\"",
+                to_charptr(rb_obj_class(value)),
+                Sfcc_cim_type_to_cstr(d->type));
+      }
+      break;
+
+    /* not yet supported
+    case T_HASH:
+      // this would result in CIMCArgs ... is this really needed?
+    break;
+    */
+
+    case T_DATA:
+      /* handle wrapped objects
+       * these will be destructed upon garbage collection
+       * by corresponding destructors of their ruby objects
+       *
+       * so data->reference must by set to true
+       */
+    default:
+      if (CLASS_OF(value) == cSfccCimString) {
+        if (d->type == CIMC_string) {
+          Data_Get_Struct(value, CIMCString, d->value.string);
+          data->reference = true;
+        }else {
+          d->state = CIMC_badValue;
+          rb_raise(rb_eTypeError, "string value can be set only for"
+                 " String type");
+        }
+      }else STORE_DATA_VAL(Instance, instance, inst, inst, instance)
+      else  STORE_DATA_VAL(ObjectPath, object_path, op, ref, ref)
+      else  STORE_DATA_VAL(Enumeration, enumeration, enm, Enum, enumeration)
+      else if (CLASS_OF(value) == cSfccCimClass) {
+        if (d->type == CIMC_class) {
+          Data_Get_Struct(value, CIMCClass, d->value.cls);
+          data->reference = true;
+        }else {
+          d->state = CIMC_badValue;
+          rb_raise(rb_eTypeError,
+                  "class can only be set for Class type");
+        }
+      }else {
+        VALUE cname;
+        const char *class_name;
+        d->state = CIMC_badValue;
+        cname = rb_funcall(rb_funcall(value, rb_intern("class"), 0),
+                rb_intern("to_s"), 0);
+        class_name = to_charptr(cname);
+        rb_raise(rb_eTypeError, "unsupported data type: %s",
+                class_name);
+      }
+  }
+}
+
+/**
+ * call-seq:
+ *  new(type, value)                   -> Cim::Data
+ *  new("Reference", op)               -> Cim::Data
+ *  new("Cim::Type::String", "string") -> Cim::Data
+ *
+ * Creates a new data object from +type+ and +value+.
+ * +value+'s type must correspond to +type+, otherwise a +TypeError+ is raised.
+ * Also if +value+ is an +Array+, then all of its elements must be of the
+ * same type.
+ *
+ * +type+ can be given as +String+ or as +Symbol+ from +Cim::Type+.
+ */
+static VALUE new(VALUE klass, VALUE type, VALUE value)
+{
+  VALUE res = Qnil;
+  CIMCData tmp;
+  tmp.state = CIMC_nullValue;
+  tmp.type = CIMC_null;
+  if ((res = Sfcc_wrap_cim_data(&tmp)) != Qnil) {
+    rb_sfcc_data *data;
+    Data_Get_Struct(res, rb_sfcc_data, data);
+    do_set_type(data, type);
+    do_set_value(data, value); //make a deep copy of value
+    rb_obj_call_init(res, 0, NULL);
+  }
+  return res;
+}
+
+/**
+ * call-seq:
+ *  from_value(123)       -> Cim::Data
+ *  from_value("string")  -> Cim::Data
+ *  from_value([1, 2, 3]) -> Cim::Data
+ *
+ * Created a new data object from +value+ only. The +Cim::Type+ is guessed
+ * from type of +value+:
+ *  * +String+             -> +Cim::Type::String+
+ *  * +Fixnum+ or +Bignum+ -> +Cim::Type::SInt64+
+ *  * +Float+              -> +Cim::Type::Real64+
+ *  * +Array+ containing values of type xy -> Cim::Type::xyA
+ * any wrapped cimc objects in Cim namespace are also supported
+ */
+static VALUE from_value(VALUE klass, VALUE value)
+{
+  VALUE res = Qnil;
+  CIMCData tmp;
+  tmp.state = CIMC_nullValue;
+  tmp.type = CIMC_null;
+  if ((res = Sfcc_wrap_cim_data(&tmp)) != Qnil) {
+    rb_sfcc_data *data;
+    Data_Get_Struct(res, rb_sfcc_data, data);
+    data->data = sfcc_value_to_cimdata(value);
+    /* if value is a cimc wrapped object, then set the reference */
+    data->reference = TYPE(value) == T_DATA ? true:false;
+  }
+  return res;
 }
 
 /**
@@ -17,9 +390,9 @@ dealloc(CIMCData *data)
  */
 static VALUE state(VALUE self)
 {
-  CIMCData *data;
-  Data_Get_Struct(self, CIMCData, data);
-  return UINT2NUM(data->state);
+  rb_sfcc_data *data;
+  Data_Get_Struct(self, rb_sfcc_data, data);
+  return UINT2NUM(data->data.state);
 }
 
 /**
@@ -30,9 +403,26 @@ static VALUE state(VALUE self)
  */
 static VALUE type(VALUE self)
 {
-  CIMCData *data;
-  Data_Get_Struct(self, CIMCData, data);
-  return Sfcc_wrap_cim_type(data->type);
+  rb_sfcc_data *data;
+  Data_Get_Struct(self, rb_sfcc_data, data);
+  return Sfcc_wrap_cim_type(data->data.type);
+}
+
+/**
+ * call-seq:
+ *  type = "Reference"
+ *  type = Cim::Type::Reference
+ *
+ * Sets the type of +Cim::Data+.
+ *
+ * +type+ can be either +String+ or a +Symbol+ from +Cim::Type+ namespace.
+ */
+static VALUE set_type(VALUE self, VALUE type)
+{
+  rb_sfcc_data *data;
+  Data_Get_Struct(self, rb_sfcc_data, data);
+  do_set_type(data, type);
+  return type;
 }
 
 /**
@@ -43,11 +433,28 @@ static VALUE type(VALUE self)
  */
 static VALUE value(VALUE self)
 {
-  CIMCData *data;
-  Data_Get_Struct(self, CIMCData, data);
-  return sfcc_cimdata_to_value(data, Qnil);
+  rb_sfcc_data *data;
+  Data_Get_Struct(self, rb_sfcc_data, data);
+  return sfcc_cimdata_to_value(&data->data, Qnil);
 }
 
+/**
+ * call-seq:
+ *  value=(10)
+ *  value=(["abc", "def"])
+ *
+ * Set value of data.
+ *
+ * +value+ must be convertible to data's type, otherwise a +TypeError+ will
+ * be raised.
+ */
+static VALUE set_value(VALUE self, VALUE value)
+{
+  rb_sfcc_data *data;
+  Data_Get_Struct(self, rb_sfcc_data, data);
+  do_set_value(data, value);
+  return value;
+}
 
 /**
  * call-seq:
@@ -57,9 +464,10 @@ static VALUE value(VALUE self)
  */
 static VALUE state_is(VALUE self, VALUE state)
 {
-  CIMCData *data;
-  Data_Get_Struct(self, CIMCData, data);
-  if (data->state & FIX2INT(state))
+  Check_Type(state, T_FIXNUM);
+  rb_sfcc_data *data;
+  Data_Get_Struct(self, rb_sfcc_data, data);
+  if (data->data.state == FIX2INT(state))
     return Qtrue;
   return Qfalse;
 }
@@ -68,15 +476,21 @@ static VALUE state_is(VALUE self, VALUE state)
 VALUE
 Sfcc_wrap_cim_data(CIMCData *data)
 {
-  CIMCData *ptr = (CIMCData *)malloc(sizeof(CIMCData));
-  if (!ptr)
-    rb_raise(rb_eNoMemError, "Cannot alloc rb_sfcc_data");
-  memcpy(ptr, data, sizeof(CIMCData));
-  return Data_Wrap_Struct(cSfccCimData, NULL, dealloc, ptr);
+  rb_sfcc_data *d = malloc(sizeof(rb_sfcc_data));
+  if (!d) {
+    rb_raise(rb_eNoMemError, "failed to allocate data");
+    return Qnil;
+  }
+  d->data = *data;
+  d->reference = true;
+  return Data_Wrap_Struct(cSfccCimData, NULL, dealloc, d);
 }
 
+void Sfcc_clear_cim_data(CIMCData *data)
+{
+  clear_cimdata(data);
+}
 
-VALUE cSfccCimData;
 void init_cim_data()
 {
   VALUE sfcc = rb_define_module("Sfcc");
@@ -88,9 +502,13 @@ void init_cim_data()
   VALUE klass = rb_define_class_under(cimc, "Data", rb_cObject);
   cSfccCimData = klass;
 
+  rb_define_singleton_method(klass, "new", new, 2);
+  rb_define_singleton_method(klass, "from_value", from_value, 1);
   rb_define_method(klass, "state", state, 0);
   rb_define_method(klass, "type", type, 0);
+  rb_define_method(klass, "type=", set_type, 1);
   rb_define_method(klass, "value", value, 0);
+  rb_define_method(klass, "value=", set_value, 1);
 
   /* Value state */
   rb_define_method(klass, "state_is", state_is, 1);

--- a/ext/sfcc/cim_data.h
+++ b/ext/sfcc/cim_data.h
@@ -8,5 +8,10 @@ void init_cim_data();
 
 extern VALUE cSfccCimData;
 VALUE Sfcc_wrap_cim_data(CIMCData *data);
+/**
+ * deallocates inner value in case of pointer to data
+ * not the CIMCData object itself
+ */
+void Sfcc_clear_cim_data(CIMCData *data);
 
 #endif

--- a/ext/sfcc/cim_type.c
+++ b/ext/sfcc/cim_type.c
@@ -121,6 +121,12 @@ Sfcc_wrap_cim_type(CIMCType type)
   return Data_Wrap_Struct(cSfccCimType, NULL, dealloc, rst);
 }
 
+/**
+ * helper macro to define integer constant under Cim::Type
+ * in function below
+ */
+#define TYPEDEF(name, val) \
+    rb_define_const(klass, name, INT2FIX(val));
 
 VALUE cSfccCimType;
 void init_cim_type()
@@ -141,88 +147,88 @@ void init_cim_type()
    * data on the CIM namespace
    */
 
-  rb_define_const(klass, "Null",        INT2FIX(CIMC_null));
+  TYPEDEF("Null"        , CIMC_null);
 
-  rb_define_const(klass, "SIMPLE",      INT2FIX(CIMC_SIMPLE));
-  rb_define_const(klass, "Boolean",     INT2FIX(CIMC_boolean));
-  rb_define_const(klass, "Char16",      INT2FIX(CIMC_char16));
+  TYPEDEF("SIMPLE"      , CIMC_SIMPLE);
+  TYPEDEF("Boolean"     , CIMC_boolean);
+  TYPEDEF("Char16"      , CIMC_char16);
 
-  rb_define_const(klass, "REAL",        INT2FIX(CIMC_REAL));
-  rb_define_const(klass, "Real32",      INT2FIX(CIMC_real32));
-  rb_define_const(klass, "Real64",      INT2FIX(CIMC_real64));
+  TYPEDEF("REAL"        , CIMC_REAL);
+  TYPEDEF("Real32"      , CIMC_real32);
+  TYPEDEF("Real64"      , CIMC_real64);
 
-  rb_define_const(klass, "UINT",        INT2FIX(CIMC_UINT));
-  rb_define_const(klass, "UInt8",       INT2FIX(CIMC_uint8));
-  rb_define_const(klass, "UInt16",      INT2FIX(CIMC_uint16));
-  rb_define_const(klass, "UInt32",      INT2FIX(CIMC_uint32));
-  rb_define_const(klass, "UInt64",      INT2FIX(CIMC_uint64));
-  rb_define_const(klass, "SINT",        INT2FIX(CIMC_SINT));
-  rb_define_const(klass, "SInt8",       INT2FIX(CIMC_sint8));
-  rb_define_const(klass, "SInt16",      INT2FIX(CIMC_sint16));
-  rb_define_const(klass, "SInt32",      INT2FIX(CIMC_sint32));
-  rb_define_const(klass, "SInt64",      INT2FIX(CIMC_sint64));
-  rb_define_const(klass, "INTEGER",     INT2FIX(CIMC_INTEGER));
+  TYPEDEF("UINT"        , CIMC_UINT);
+  TYPEDEF("UInt8"       , CIMC_uint8);
+  TYPEDEF("UInt16"      , CIMC_uint16);
+  TYPEDEF("UInt32"      , CIMC_uint32);
+  TYPEDEF("UInt64"      , CIMC_uint64);
+  TYPEDEF("SINT"        , CIMC_SINT);
+  TYPEDEF("SInt8"       , CIMC_sint8);
+  TYPEDEF("SInt16"      , CIMC_sint16);
+  TYPEDEF("SInt32"      , CIMC_sint32);
+  TYPEDEF("SInt64"      , CIMC_sint64);
+  TYPEDEF("INTEGER"     , CIMC_INTEGER);
 
-  rb_define_const(klass, "ENC",         INT2FIX(CIMC_ENC));
-  rb_define_const(klass, "Instance",    INT2FIX(CIMC_instance));
-  rb_define_const(klass, "Reference",   INT2FIX(CIMC_ref));
-  rb_define_const(klass, "Args",        INT2FIX(CIMC_args));
-  rb_define_const(klass, "Class",       INT2FIX(CIMC_class));
-  rb_define_const(klass, "Filter",      INT2FIX(CIMC_filter));
-  rb_define_const(klass, "Enumeration", INT2FIX(CIMC_enumeration));
-  rb_define_const(klass, "String",      INT2FIX(CIMC_string));
-  rb_define_const(klass, "Chars",       INT2FIX(CIMC_chars));
-  rb_define_const(klass, "DateTime",    INT2FIX(CIMC_dateTime));
-  rb_define_const(klass, "Ptr",         INT2FIX(CIMC_ptr));
-  rb_define_const(klass, "CharsPtr",    INT2FIX(CIMC_charsptr));
+  TYPEDEF("ENC"         , CIMC_ENC);
+  TYPEDEF("Instance"    , CIMC_instance);
+  TYPEDEF("Reference"   , CIMC_ref);
+  TYPEDEF("Args"        , CIMC_args);
+  TYPEDEF("Class"       , CIMC_class);
+  TYPEDEF("Filter"      , CIMC_filter);
+  TYPEDEF("Enumeration" , CIMC_enumeration);
+  TYPEDEF("String"      , CIMC_string);
+  TYPEDEF("Chars"       , CIMC_chars);
+  TYPEDEF("DateTime"    , CIMC_dateTime);
+  TYPEDEF("Ptr"         , CIMC_ptr);
+  TYPEDEF("CharsPtr"    , CIMC_charsptr);
 
-  rb_define_const(klass, "ARRAY",       INT2FIX(CIMC_ARRAY)); /*        ((1)<<13) */
-  rb_define_const(klass, "SIMPLEA",     INT2FIX(CIMC_SIMPLEA)); /*      (CIMC_ARRAY | CIMC_SIMPLE) */
-  rb_define_const(klass, "BooleanA",    INT2FIX(CIMC_booleanA)); /*     (CIMC_ARRAY | CIMC_boolean) */
-  rb_define_const(klass, "Char16A",     INT2FIX(CIMC_char16A)); /*      (CIMC_ARRAY | CIMC_char16) */
+  TYPEDEF("ARRAY"      , CIMC_ARRAY); /*    ((1)<<13) */
+  TYPEDEF("SIMPLEA"    , CIMC_SIMPLEA); /*  (CIMC_ARRAY | CIMC_SIMPLE) */
+  TYPEDEF("BooleanA"   , CIMC_booleanA); /* (CIMC_ARRAY | CIMC_boolean) */
+  TYPEDEF("Char16A"    , CIMC_char16A); /*  (CIMC_ARRAY | CIMC_char16) */
 
-  rb_define_const(klass, "REALA",       INT2FIX(CIMC_REALA)); /*        (CIMC_ARRAY | CIMC_REAL) */
-  rb_define_const(klass, "Real32A",     INT2FIX(CIMC_real32A)); /*      (CIMC_ARRAY | CIMC_real32) */
-  rb_define_const(klass, "Real64A",     INT2FIX(CIMC_real64A)); /*      (CIMC_ARRAY | CIMC_real64) */
+  TYPEDEF("REALA"      , CIMC_REALA); /*    (CIMC_ARRAY | CIMC_REAL) */
+  TYPEDEF("Real32A"    , CIMC_real32A); /*  (CIMC_ARRAY | CIMC_real32) */
+  TYPEDEF("Real64A"    , CIMC_real64A); /*  (CIMC_ARRAY | CIMC_real64) */
 
-  rb_define_const(klass, "UNITA",       INT2FIX(CIMC_UINTA)); /*        (CIMC_ARRAY | CIMC_UINT) */
-  rb_define_const(klass, "UInt8A",      INT2FIX(CIMC_uint8A)); /*       (CIMC_ARRAY | CIMC_uint8) */
-  rb_define_const(klass, "UInt16A",     INT2FIX(CIMC_uint16A)); /*      (CIMC_ARRAY | CIMC_uint16) */
-  rb_define_const(klass, "UInt32A",     INT2FIX(CIMC_uint32A)); /*      (CIMC_ARRAY | CIMC_uint32) */
-  rb_define_const(klass, "UInt64A",     INT2FIX(CIMC_uint64A)); /*      (CIMC_ARRAY | CIMC_uint64) */
-  rb_define_const(klass, "SINTA",       INT2FIX(CIMC_SINTA)); /*        (CIMC_ARRAY | CIMC_SINT) */
-  rb_define_const(klass, "SInt8A",      INT2FIX(CIMC_sint8A)); /*       (CIMC_ARRAY | CIMC_sint8) */
-  rb_define_const(klass, "SInt16A",     INT2FIX(CIMC_sint16A)); /*      (CIMC_ARRAY | CIMC_sint16) */
-  rb_define_const(klass, "SInt32A",     INT2FIX(CIMC_sint32A)); /*      (CIMC_ARRAY | CIMC_sint32) */
-  rb_define_const(klass, "SInt64A",     INT2FIX(CIMC_sint64A)); /*      (CIMC_ARRAY | CIMC_sint64) */
-  rb_define_const(klass, "INTEGERA",    INT2FIX(CIMC_INTEGERA)); /*     (CIMC_ARRAY | CIMC_INTEGER) */
+  TYPEDEF("UNITA"      , CIMC_UINTA); /*    (CIMC_ARRAY | CIMC_UINT) */
+  TYPEDEF("UInt8A"     , CIMC_uint8A); /*   (CIMC_ARRAY | CIMC_uint8) */
+  TYPEDEF("UInt16A"    , CIMC_uint16A); /*  (CIMC_ARRAY | CIMC_uint16) */
+  TYPEDEF("UInt32A"    , CIMC_uint32A); /*  (CIMC_ARRAY | CIMC_uint32) */
+  TYPEDEF("UInt64A"    , CIMC_uint64A); /*  (CIMC_ARRAY | CIMC_uint64) */
+  TYPEDEF("SINTA"      , CIMC_SINTA); /*    (CIMC_ARRAY | CIMC_SINT) */
+  TYPEDEF("SInt8A"     , CIMC_sint8A); /*   (CIMC_ARRAY | CIMC_sint8) */
+  TYPEDEF("SInt16A"    , CIMC_sint16A); /*  (CIMC_ARRAY | CIMC_sint16) */
+  TYPEDEF("SInt32A"    , CIMC_sint32A); /*  (CIMC_ARRAY | CIMC_sint32) */
+  TYPEDEF("SInt64A"    , CIMC_sint64A); /*  (CIMC_ARRAY | CIMC_sint64) */
+  TYPEDEF("INTEGERA"   , CIMC_INTEGERA); /* (CIMC_ARRAY | CIMC_INTEGER) */
 
-  rb_define_const(klass, "ENCA",        INT2FIX(CIMC_ENCA)); /*         (CIMC_ARRAY | CIMC_ENC) */
-  rb_define_const(klass, "StringA",     INT2FIX(CIMC_stringA)); /*      (CIMC_ARRAY | CIMC_string) */
-  rb_define_const(klass, "CharsA",      INT2FIX(CIMC_charsA)); /*       (CIMC_ARRAY | CIMC_chars) */
-  rb_define_const(klass, "DataTimeA",   INT2FIX(CIMC_dateTimeA)); /*    (CIMC_ARRAY | CIMC_dateTime) */
-  rb_define_const(klass, "InstanceA",   INT2FIX(CIMC_instanceA)); /*    (CIMC_ARRAY | CIMC_instance) */
-  rb_define_const(klass, "ReferenceA",  INT2FIX(CIMC_refA)); /*         (CIMC_ARRAY | CIMC_ref) */
-  rb_define_const(klass, "PtrA",        INT2FIX(CIMC_ptrA)); /*         (CIMC_ARRAY | CIMC_ptr) */
-  rb_define_const(klass, "CharsPtrA",   INT2FIX(CIMC_charsptrA)); /*    (CIMC_ARRAY | CIMC_charsptr) */
+  TYPEDEF("ENCA"       , CIMC_ENCA); /*     (CIMC_ARRAY | CIMC_ENC) */
+  TYPEDEF("StringA"    , CIMC_stringA); /*  (CIMC_ARRAY | CIMC_string) */
+  TYPEDEF("CharsA"     , CIMC_charsA); /*   (CIMC_ARRAY | CIMC_chars) */
+  TYPEDEF("DataTimeA"  , CIMC_dateTimeA); /*(CIMC_ARRAY | CIMC_dateTime) */
+  TYPEDEF("InstanceA"  , CIMC_instanceA); /*(CIMC_ARRAY | CIMC_instance) */
+  TYPEDEF("ReferenceA" , CIMC_refA); /*     (CIMC_ARRAY | CIMC_ref) */
+  TYPEDEF("PtrA"       , CIMC_ptrA); /*     (CIMC_ARRAY | CIMC_ptr) */
+  TYPEDEF("CharsPtrA"  , CIMC_charsptrA); /*(CIMC_ARRAY | CIMC_charsptr) */
 
   // the following are cimcObjectPath key-types synonyms
   // and are valid only when CIMC_keyValue of cimcValueState is set
 
-  rb_define_const(klass, "KeyInteger",  INT2FIX(CIMC_keyInteger)); /*   (CIMC_sint64) */
-  rb_define_const(klass, "KeyString",   INT2FIX(CIMC_keyString)); /*   (CIMC_string) */
-  rb_define_const(klass, "KeyBoolean",  INT2FIX(CIMC_keyBoolean)); /*   (CIMC_boolean) */
-  rb_define_const(klass, "KeyReference",INT2FIX(CIMC_keyRef)); /*       (CIMC_ref) */
+  TYPEDEF("KeyInteger"   , CIMC_keyInteger); /*   (CIMC_sint64) */
+  TYPEDEF("KeyString"    , CIMC_keyString); /*    (CIMC_string) */
+  TYPEDEF("KeyBoolean"   , CIMC_keyBoolean); /*   (CIMC_boolean) */
+  TYPEDEF("KeyReference" , CIMC_keyRef); /*       (CIMC_ref) */
 
   // the following are predicate types only
 
-  rb_define_const(klass, "CharString",      INT2FIX(CIMC_charString)); /*      (CIMC_string) */
-  rb_define_const(klass, "IntegerString",   INT2FIX(CIMC_integerString)); /*   (CIMC_string | CIMC_sint64) */
-  rb_define_const(klass, "RealString",      INT2FIX(CIMC_realString)); /*      (CIMC_string | CIMC_real64) */
-  rb_define_const(klass, "NumericString",   INT2FIX(CIMC_numericString)); /*   (CIMC_string | CIMC_sint64 | CIMC_real64) */
-  rb_define_const(klass, "BooleanString",   INT2FIX(CIMC_booleanString)); /*   (CIMC_string | CIMC_boolean) */
-  rb_define_const(klass, "DateTimeString",  INT2FIX(CIMC_dateTimeString)); /*  (CIMC_string | CIMC_dateTime) */
-  rb_define_const(klass, "ClassNameString", INT2FIX(CIMC_classNameString)); /* (CIMC_string | CIMC_class) */
-  rb_define_const(klass, "NameString",      INT2FIX(CIMC_nameString)); /*      (CIMC_string | ((16+10)<<8)) */
+  TYPEDEF("CharString"      , CIMC_charString); /*      (CIMC_string) */
+  TYPEDEF("IntegerString"   , CIMC_integerString); /*   (CIMC_string | CIMC_sint64) */
+  TYPEDEF("RealString"      , CIMC_realString); /*      (CIMC_string | CIMC_real64) */
+  TYPEDEF("NumericString"   , CIMC_numericString); /*   (CIMC_string | CIMC_sint64 | CIMC_real64) */
+  TYPEDEF("BooleanString"   , CIMC_booleanString); /*   (CIMC_string | CIMC_boolean) */
+  TYPEDEF("DateTimeString"  , CIMC_dateTimeString); /*  (CIMC_string | CIMC_dateTime) */
+  TYPEDEF("ClassNameString" , CIMC_classNameString); /* (CIMC_string | CIMC_class) */
+  TYPEDEF("NameString"      , CIMC_nameString); /*      (CIMC_string | ((16+10)<<8)) */
 
 }

--- a/ext/sfcc/cim_type.c
+++ b/ext/sfcc/cim_type.c
@@ -6,13 +6,20 @@
 #include "cim_type.h"
 
 typedef struct {
-  unsigned int type;
+  CIMCType type;
 } rb_sfcc_type;
 
 static void
 dealloc(rb_sfcc_type *type)
 {
   free(type);
+}
+
+CIMCType Sfcc_rb_type_to_cimtype(VALUE self)
+{
+  rb_sfcc_type *type;
+  Data_Get_Struct(self, rb_sfcc_type, type);
+  return type->type;
 }
 
 /**
@@ -23,26 +30,12 @@ dealloc(rb_sfcc_type *type)
  */
 static VALUE to_i(VALUE self)
 {
-  rb_sfcc_type *type;
-  Data_Get_Struct(self, rb_sfcc_type, type);
-
-  return INT2FIX(type->type);
+  return INT2FIX(Sfcc_rb_type_to_cimtype(self));
 }
 
-
-/**
- * call-seq:
- *   to_s() -> String
- *
- * String representation of type
- */
-static VALUE to_s(VALUE self)
-{
-  rb_sfcc_type *type;
-  const char *s;
-  Data_Get_Struct(self, rb_sfcc_type, type);
-
-  switch (type->type) {
+char const * Sfcc_cim_type_to_cstr(CIMCType type) {
+  const char *s = NULL;
+  switch (type) {
     case CIMC_null: s = "null"; break;
     
     case CIMC_boolean: s = "boolean"; break;
@@ -99,12 +92,27 @@ static VALUE to_s(VALUE self)
     rb_raise(rb_eTypeError, "Unknown Cim::Type");
     break;
   }
-  return rb_str_new2(s);
+  return s;
+}
+
+/**
+ * call-seq:
+ *   to_s() -> String
+ *
+ * String representation of type
+ */
+static VALUE to_s(VALUE self)
+{
+  char const * s = Sfcc_cim_type_to_cstr(Sfcc_rb_type_to_cimtype(self));
+  if (s) {
+    return rb_str_new2(s);
+  }
+  return Qnil;
 }
 
 
 VALUE
-Sfcc_wrap_cim_type(unsigned int type)
+Sfcc_wrap_cim_type(CIMCType type)
 {
   rb_sfcc_type *rst = (rb_sfcc_type *)malloc(sizeof(rb_sfcc_type));
   if (!rst)

--- a/ext/sfcc/cim_type.h
+++ b/ext/sfcc/cim_type.h
@@ -7,6 +7,8 @@
 void init_cim_type();
 
 extern VALUE cSfccCimType;
-VALUE Sfcc_wrap_cim_type(unsigned int type);
+VALUE Sfcc_wrap_cim_type(CIMCType type);
+char const * Sfcc_cim_type_to_cstr(CIMCType type);
+CIMCType Sfcc_rb_type_to_cimtype(VALUE type);
 
 #endif

--- a/ext/sfcc/sfcc.c
+++ b/ext/sfcc/sfcc.c
@@ -39,7 +39,10 @@ void Init_sfcc()
   VALUE value; /* wrapped value */
   int rc;
   char *msg;
+
+#ifdef CIMC_NO_CURL_INIT //defined in cimc/cimc.h since version 2.2.4
   char *rails_env = getenv("RAILS_ENV");
+#endif
 
   /**
    * SBLIM sfcc ruby API
@@ -56,8 +59,13 @@ void Init_sfcc()
   cEnvironment = rb_define_class_under(mSfccCim, "CimcEnvironment", rb_cObject);
   conn = getenv("RUBY_SFCC_CONNECTION"); /* "SfcbLocal" or "XML" */
   if (!conn) conn = "XML";
-  /* Don't let sfcc init curl if running in Rails env (http://sourceforge.net/tracker/?func=detail&aid=3435363&group_id=128809&atid=712784) */
-  cimcEnv = NewCIMCEnv(conn, rails_env?CIMC_NO_CURL_INIT:0, &rc, &msg);
+  cimcEnv = NewCIMCEnv(conn,
+#ifdef CIMC_NO_CURL_INIT
+  /* Don't let sfcc init curl if running in Rails env
+   * (http://sourceforge.net/tracker/?func=detail&aid=3435363&group_id=128809&atid=712784) */
+        rails_env?CIMC_NO_CURL_INIT:
+#endif
+        0, &rc, &msg);
   if (!cimcEnv) {
     rb_raise(rb_eLoadError, "Cannot local %s cim client library. %d:%s", conn, rc, msg ? msg : "");
   }

--- a/ext/sfcc/sfcc.c
+++ b/ext/sfcc/sfcc.c
@@ -384,11 +384,15 @@ CIMCData sfcc_value_to_cimdata(VALUE value)
     data.type = CIMC_sint64;
     data.value.Long = NUM2INT(value);
     break;
-/* not yet supported
-  case T_BIGNUM:
-    break;
   case T_FLOAT:
+    data.type = CIMC_real64;
+    data.value.real64 = NUM2DBL(value);
     break;
+  case T_BIGNUM:
+    data.type = CIMC_sint64;
+    data.value.Long = NUM2LL(value);
+    break;
+/* not yet supported
   case T_HASH:
     break;
   case T_SYMBOL:

--- a/ext/sfcc/sfcc.c
+++ b/ext/sfcc/sfcc.c
@@ -482,6 +482,48 @@ CIMCData sfcc_value_to_cimdata(VALUE value)
       Data_Get_Struct(value, CIMCData, tmp);
       data = *tmp;
     }
+    else if(CLASS_OF(value) == cSfccCimInstance) {
+      rb_sfcc_instance *obj;
+      Data_Get_Struct(value, rb_sfcc_instance, obj);
+      data.value.inst = obj->inst;
+      if (data.value.inst == NULL) {
+        data.type = CIMC_null;
+        data.state = CIMC_nullValue;
+      }else {
+        data.type = CIMC_instance;
+      }
+    }
+    else if(CLASS_OF(value) == cSfccCimObjectPath) {
+      rb_sfcc_object_path *obj;
+      Data_Get_Struct(value, rb_sfcc_object_path, obj);
+      data.value.ref = obj->op;
+      if (data.value.ref == NULL) {
+        data.type = CIMC_null;
+        data.state = CIMC_nullValue;
+      }else {
+        data.type = CIMC_ref;
+      }
+    }
+    else if(CLASS_OF(value) == cSfccCimEnumeration) {
+      rb_sfcc_enumeration *obj;
+      Data_Get_Struct(value, rb_sfcc_enumeration, obj);
+      data.value.Enum = obj->enm;
+      if (data.value.Enum == NULL) {
+        data.type = CIMC_null;
+        data.state = CIMC_nullValue;
+      }else {
+        data.type = CIMC_enumeration;
+      }
+    }
+    else if (CLASS_OF(value) == cSfccCimClass) {
+      Data_Get_Struct(value, CIMCClass, data.value.cls);
+      if (data.value.cls == NULL) {
+        data.type = CIMC_null;
+        data.state = CIMC_nullValue;
+      }else {
+        data.type = CIMC_class;
+      }
+    }
     else {
       VALUE cname;
       const char *class_name;

--- a/ext/sfcc/sfcc.c
+++ b/ext/sfcc/sfcc.c
@@ -237,6 +237,7 @@ VALUE sfcc_cimdata_to_value(CIMCData *data, VALUE client)
       }
       return Qnil;
     case CIMC_chars:
+      return data->value.chars ? rb_str_new2(data->value.chars) : Qnil;
     case CIMC_charsptr:
       return data->value.chars ? rb_str_new((char*)data->value.dataPtr.ptr, data->value.dataPtr.length) : Qnil;
     case CIMC_dateTime:

--- a/ext/sfcc/sfcc.h
+++ b/ext/sfcc/sfcc.h
@@ -59,6 +59,17 @@ inline CIMCArgs* sfcc_hash_to_cimargs(VALUE hash);
 inline VALUE sfcc_cimargs_to_hash(CIMCArgs *args, VALUE client);
 
 /**
+ * allocates a new cimcarray and fills it with converted values of ruby array
+ *
+ * all elements of array must have the same type,
+ *   otherwise TypeError is raised
+ * @param type will contain type of array
+ *
+ * @note nested arrays are not supported
+ */
+inline CIMCArray * sfcc_rubyarray_to_cimcarray(VALUE array, CIMCType *type);
+
+/**
  * converts CIMCData to ruby VALUE
  */
 inline VALUE sfcc_cimdata_to_value(CIMCData *data, VALUE client);
@@ -67,5 +78,11 @@ inline VALUE sfcc_cimdata_to_value(CIMCData *data, VALUE client);
  * convert ruby VALUE to CIMCData
  */
 inline CIMCData sfcc_value_to_cimdata(VALUE value);
+
+/**
+ * @param v, can be Fixnum, Bignum or Float
+ * @return ruby String created from ruby number
+ */
+inline VALUE sfcc_numeric_to_str(VALUE v);
 
 #endif

--- a/test/test_sfcc_cim_data.rb
+++ b/test/test_sfcc_cim_data.rb
@@ -43,7 +43,109 @@ class SfccCimcData < SfccTestCase
         check_data d
       end      
     end
-    
+
+    should "allow to instantiate Cim::Data from value" do
+      d = Sfcc::Cim::Data.from_value("abcd")
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::String)
+      assert_equal(d.state, Sfcc::Cim::Data::Good)
+      assert_kind_of(String, d.value)
+      assert_equal(d.value, "abcd")
+      d = Sfcc::Cim::Data.from_value(45)
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::SInt64)
+      assert_equal(d.state, Sfcc::Cim::Data::Good)
+      assert_kind_of(Fixnum, d.value)
+      assert_equal(d.value, 45)
+      str = Sfcc::Cim::String.new("sfcc string")
+      d = Sfcc::Cim::Data.from_value(str)
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::String)
+      assert_equal(d.state, Sfcc::Cim::Data::Good)
+      assert_kind_of(String, d.value)
+      assert_equal(d.value, "sfcc string")
+      d = Sfcc::Cim::Data.from_value(nil)
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::Null)
+      assert_equal(d.state, Sfcc::Cim::Data::Null)
+      assert_equal(d.value, nil)
+      d = Sfcc::Cim::Data.from_value(4.32)
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::Real64)
+      assert_equal(d.state, Sfcc::Cim::Data::Good)
+      assert_equal(d.value, 4.32)
+    end
+
+    should "allow to instantiate integer from string" do
+      d = Sfcc::Cim::Data.new(Sfcc::Cim::Type::SInt8, "-2")
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::SInt8)
+      assert_equal(d.state, Sfcc::Cim::Data::Good)
+      assert_equal(d.value, -2)
+      d = Sfcc::Cim::Data.new(Sfcc::Cim::Type::SInt8, "266")
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::SInt8)
+      assert_equal(d.state, Sfcc::Cim::Data::Good)
+      assert_equal(d.value, 10)
+    end
+
+    should "allow to instantiate Cim::Data with type as string" do
+      d = Sfcc::Cim::Data.new("String", "abc")
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::String)
+      assert_equal(d.value, "abc")
+      d = Sfcc::Cim::Data.new("UInt16", "432")
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::UInt16)
+      assert_equal(d.value, 432)
+      assert_raise NameError do
+        d = Sfcc::Cim::Data.new("unknown type", "some value")
+      end
+    end
+
+    should "allow to instantiate Cim::Data with type" do
+      d = Sfcc::Cim::Data.new(Sfcc::Cim::Type::String, "abc")
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::String)
+      assert_equal(d.state, Sfcc::Cim::Data::Good)
+      assert_equal(d.value, "abc")
+      d = Sfcc::Cim::Data.new(Sfcc::Cim::Type::UInt8, 10)
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::UInt8)
+      assert_equal(d.state, Sfcc::Cim::Data::Good)
+      assert_equal(d.value, 10)
+      assert_raise TypeError do
+        d = Sfcc::Cim::Data.new(Sfcc::Cim::Type::Reference, "not a reference")
+      end
+    end
+
+    should "allow to change type of Cim::Data" do
+      d = Sfcc::Cim::Data.new(Sfcc::Cim::Type::String, "abc")
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::String)
+      d.type = Sfcc::Cim::Type::SInt16
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::SInt16)
+      assert_equal(d.state, Sfcc::Cim::Data::Null)
+      assert_equal(d.value, nil)
+      d.type = "UInt16"
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::UInt16)
+      d2 = Sfcc::Cim::Data.new(Sfcc::Cim::Type::String, "abcd")
+      assert_equal(d2.type.to_i, Sfcc::Cim::Type::String)
+      d2.type = d.type
+      assert_equal(d2.type.to_i, Sfcc::Cim::Type::UInt16)
+    end
+
+    should "allow to change value of Cim::Data" do
+      d = Sfcc::Cim::Data.new(Sfcc::Cim::Type::String, "abc")
+      assert_equal(d.value, "abc")
+      d.value = Sfcc::Cim::String.new("tmp string")
+      assert_equal(d.value, "tmp string")
+      d.type = Sfcc::Cim::Type::Real64
+      assert_equal(d.state, Sfcc::Cim::Data::Null)
+      d.value = 15.2
+      assert_equal(d.state, Sfcc::Cim::Data::Good)
+      assert_equal(d.value, 15.2)
+    end
+
+    should "allow to instantiate Cim::Data from array" do
+      d = Sfcc::Cim::Data.new("StringA", ["abc", "def"])
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::StringA)
+      assert_kind_of(Array, d.value)
+      assert_equal(d.value, ["abc", "def"])
+      # forbid array creation from array with different value types
+      assert_raise TypeError do
+        d = Sfcc::Cim::Data.from_value([1, "string"])
+      end
+    end
+
   end
   
 end

--- a/test/test_sfcc_cim_data.rb
+++ b/test/test_sfcc_cim_data.rb
@@ -61,6 +61,11 @@ class SfccCimcData < SfccTestCase
       assert_equal(d.state, Sfcc::Cim::Data::Good)
       assert_kind_of(String, d.value)
       assert_equal(d.value, "sfcc string")
+      op = Sfcc::Cim::ObjectPath.new("namespace", "classname")
+      d = Sfcc::Cim::Data.from_value(op)
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::Reference)
+      assert_equal(d.state, Sfcc::Cim::Data::Good)
+      assert_kind_of(Sfcc::Cim::ObjectPath, d.value)
       d = Sfcc::Cim::Data.from_value(nil)
       assert_equal(d.type.to_i, Sfcc::Cim::Type::Null)
       assert_equal(d.state, Sfcc::Cim::Data::Null)
@@ -89,6 +94,10 @@ class SfccCimcData < SfccTestCase
       d = Sfcc::Cim::Data.new("UInt16", "432")
       assert_equal(d.type.to_i, Sfcc::Cim::Type::UInt16)
       assert_equal(d.value, 432)
+      op = Sfcc::Cim::ObjectPath.new("namespace", "classname")
+      d = Sfcc::Cim::Data.new("Reference", op)
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::Reference)
+      assert_kind_of(Sfcc::Cim::ObjectPath, d.value)
       assert_raise NameError do
         d = Sfcc::Cim::Data.new("unknown type", "some value")
       end
@@ -105,6 +114,10 @@ class SfccCimcData < SfccTestCase
       assert_equal(d.value, 10)
       assert_raise TypeError do
         d = Sfcc::Cim::Data.new(Sfcc::Cim::Type::Reference, "not a reference")
+      end
+      assert_raise TypeError do
+        d = Sfcc::Cim::Data.new(
+          "String", Sfcc::Cim::ObjectPath.new("namespace", "classname"))
       end
     end
 
@@ -128,6 +141,9 @@ class SfccCimcData < SfccTestCase
       assert_equal(d.value, "abc")
       d.value = Sfcc::Cim::String.new("tmp string")
       assert_equal(d.value, "tmp string")
+      assert_raise TypeError do
+        d.value = Sfcc::Cim::ObjectPath.new("namespace", "classname")
+      end
       d.type = Sfcc::Cim::Type::Real64
       assert_equal(d.state, Sfcc::Cim::Data::Null)
       d.value = 15.2
@@ -140,12 +156,38 @@ class SfccCimcData < SfccTestCase
       assert_equal(d.type.to_i, Sfcc::Cim::Type::StringA)
       assert_kind_of(Array, d.value)
       assert_equal(d.value, ["abc", "def"])
+      d = Sfcc::Cim::Data.from_value([
+            Sfcc::Cim::ObjectPath.new("namespace", "classname"),
+            Sfcc::Cim::ObjectPath.new("nm2", "cls2")])
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::ReferenceA)
+      assert_kind_of(Array, d.value)
+      assert_equal(d.value.size, 2)
+      assert_equal(d.value[0].namespace, "namespace")
+      assert_equal(d.value[0].classname, "classname")
       # forbid array creation from array with different value types
       assert_raise TypeError do
         d = Sfcc::Cim::Data.from_value([1, "string"])
       end
     end
 
+    should "allow to instantiate Cim::Data from cimc wrapped objects" do
+      d = Sfcc::Cim::Data.from_value(@cimclass)
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::Class)
+      assert_kind_of(Sfcc::Cim::Class, d.value)
+      assert_equal(d.value.class_name, @cimclass.class_name)
+      d = Sfcc::Cim::Data.from_value(Sfcc::Cim::String.new("cimstring"))
+      assert_equal(d.type.to_i, Sfcc::Cim::Type::String)
+      assert_kind_of(String, d.value)
+      assert_equal(d.value, "cimstring")
+      @client.instances(
+              Sfcc::Cim::ObjectPath.new("root/cimv2", "CIM_ComputerSystem"),
+              Sfcc::Flags::DeepInheritance).each { |i|
+          d = Sfcc::Cim::Data.from_value(i)
+          assert_equal(d.type.to_i, Sfcc::Cim::Type::Instance)
+          assert_kind_of(Sfcc::Cim::Instance, d.value)
+      }
+    end
+
   end
-  
+
 end


### PR DESCRIPTION
Made CIMCData a ruby object to allow passing values along with types to client methods.
### Use case:
  Some C sfcb provider is accepting a UInt8 value as method parameter.
  Originally passing some integer to a method as parameter would turn in into ```CIMCData d = { .type = CIMC_sint64, .value.sint64 = val };```
  But providers are often coded in the way, that they check for exact type of input parameter and fail in case
  they not match.
  So with this modification one can write:
```
client.invoke_method(object_path, "some_method_name",
    { "Param1" => Sfcc::Cim::Data.new("UInt8", 10) }, out)
```

#### Changes from previous pull request
* I've found out, that cloning is not necessary. Operations on container cimc types (`CIMCArray`, `CIMCArgs`), like get or set attributes, do the cloning themselfs, so it is safe to release them. This greatly simplifies the code.
* Now I keep closer to upstream's coding style.
* Each commit contain atomic changes.